### PR TITLE
Move credentials to vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ This is the simplest template to start from.
 - [Robocorp Developer Training Courses](https://robocorp.com/docs/courses)
 - [Documentation links on Robot Framework](https://robocorp.com/docs/languages-and-frameworks/robot-framework)
 - [Example bots in Robocorp Portal](https://robocorp.com/portal)
+
+
+Remove the hard-coded login credentials from the robot to a vault for better security.
+
+To test this, create vault.json file in your home directory (/Users/<username>). Paste the following JSON and update the value for the username and the password properties:
+
+{
+  "robotsparebin": {
+    "username": "username-here",
+    "password": "password-here"
+  }
+}
+Upadate the path to the vault.json file in the devdata/json file.

--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,0 +1,4 @@
+{
+    "RPA_SECRET_MANAGER": "RPA.Robocorp.Vault.FileSecrets",
+    "RPA_SECRET_FILE": "C:\\Users\\AnnaRajainmaa\\vault.json"
+}

--- a/tasks.robot
+++ b/tasks.robot
@@ -5,6 +5,7 @@ Library             RPA.Browser.Selenium    auto_close=${FALSE}
 Library             RPA.Excel.Files
 Library             RPA.HTTP
 Library             RPA.PDF
+Library             RPA.Robocorp.Vault
 
 
 *** Tasks ***
@@ -23,8 +24,9 @@ Open the intranet website
     Open Available Browser    https://robotsparebinindustries.com/
 
 Log in
-    Input Text    username    maria
-    Input Password    password    thoushallnotpass
+    ${secret}=    Get Secret    robotsparebin
+    Input Text    username    ${secret}[username]
+    Input Password    password    ${secret}[password]
     Submit Form
     Wait Until Page Contains Element    id:sales-form
 


### PR DESCRIPTION
This pull request removes the hard-coded login credentials from the robot to a vault for better security.

To test this, create `vault.json` file in your home directory (`/Users/<your username>`). Paste the following JSON and update the value for the `username` and the `password` properties:

```
{
  "robotsparebin": {
    "username": "username-here",
    "password": "password-here"
  }
}
```

Upadate the path to the `vault.json` file in the `devdata/json` file.